### PR TITLE
Disable minimal build options in buildenv

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -34,7 +34,7 @@ export ZOPEN_RUNTIME_DEPS="rpm"
 export ZOPEN_SYSTEM_PREREQ=""
 
 export USE_ZOSLIB_LOCALE=1
-export USE_CLANG_WRAPPER=1
+#export USE_CLANG_WRAPPER=1
 
 ###
 ### Build stage control environment variables
@@ -175,12 +175,12 @@ export ZOPEN_CHECK_MINIMAL="yes" ## Check program will not be passed CFLAGS, LDF
 #export ZOPEN_CHECK_OPTS="-C ../build test" ## Options to pass to check program (defaults to 'check')
 #export ZOPEN_CHECK_TIMEOUT="" ## Timeout limit in seconds for the check program (defaults to '12600' # 3.5 hours)
 #export ZOPEN_CLEAN_OPTS="" ## Options to pass to clean up  program (defaults to 'clean')
-export ZOPEN_CONFIGURE_MINIMAL="yes" ## Configuration program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will get them from env vars.
+#export ZOPEN_CONFIGURE_MINIMAL="yes" ## Configuration program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will get them from env vars.
 export ZOPEN_CONFIGURE_OPTS="-B ../build --install-prefix \$ZOPEN_INSTALL_DIR/ -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCURL_LIBRARY=\"\$CURL_HOME/lib/libcurl.a\" -DCURL_INCLUDE_DIR=\"\$CURL_HOME/include\" -DZLIB_LIBRARY=\"\$ZLIB_HOME/lib/libz.a\" -DWITH_SYSTEMD=OFF -DWITH_DNF5DAEMON_CLIENT=OFF -DWITH_DNF5DAEMON_SERVER=OFF -DWITH_MODULEMD=OFF -DWITH_LIBDNF5_CLI=ON -DWITH_PLUGIN_APPSTREAM=OFF -DWITH_PYTHON_PLUGINS_LOADER=OFF -DWITH_PERL5=OFF -DWITH_PYTHON3=OFF -DWITH_RUBY=OFF -DWITH_TESTS=ON -DWITH_MAN=OFF -DWITH_HTML=OFF -DWITH_ACL=OFF" ## Options to pass to configuration program (defaults to '--prefix=')
 
 #export ZOPEN_EXTRA_CONFIGURE_OPTS="" ## Extra configure options to pass to configuration program. (defaults to '')
 export ZOPEN_INSTALL_OPTS="-C ../build install" ## Options to pass to installation program (defaults to 'install')
-export ZOPEN_MAKE_MINIMAL="yes" ## Build program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will get them from env vars.
+#export ZOPEN_MAKE_MINIMAL="yes" ## Build program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will get them from env vars.
 export ZOPEN_MAKE_OPTS="-C ../build" ## Options to pass to build program (defaults to '-j')
 #export ZOPEN_PATCH_DIR="" ## Specify directory from which patches should be applied.
 


### PR DESCRIPTION
Comment out several environment variable exports for build configuration.